### PR TITLE
Add Excel/Google Sheets export functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ This repository contains scripts for working with the Exa API to search for info
 ## Project Structure
 
 - `src/` - Python source code files
+  - `utils/` - Utility modules including Excel export functionality
 - `config/` - Configuration files
-- `results/` - Output files and results
+- `results/` - Output files and results (JSON, text, and Excel formats)
+- `tests/` - Test files for the codebase
 - `documentation.md` - Detailed API documentation
 - `README.md` - This file
 
@@ -53,13 +55,16 @@ This script uses the Exa Search API to search for information and display the re
 - Perform searches with customizable queries
 - Limit the number of results displayed
 - Format and display search results with relevant metadata
-- Save results to a file
+- Save results to both JSON/text and Excel/Google Sheets formats
+- Handle missing fields gracefully by keeping them blank in the output
 
 ## Requirements
 
 - Python 3.6+
 - `exa-py` Python package
 - `python-dotenv` package
+- `pandas` package for data manipulation
+- `openpyxl` package for Excel file generation
 
 ## Installation
 
@@ -73,7 +78,7 @@ This script uses the Exa Search API to search for information and display the re
    - On macOS/Linux: `source venv/bin/activate`
 4. Install the required packages:
    ```
-   pip install exa-py python-dotenv
+   pip install -r requirements.txt
    ```
 5. Create a `.env` file in the root directory with your Exa API key:
    ```
@@ -162,9 +167,15 @@ The script displays search results with the following information (when availabl
 - Relevance score
 - Text excerpt
 
+Results are saved in two formats:
+1. Text file (.txt) - Human-readable formatted text
+2. Excel file (.xlsx) - Tabular data for analysis and processing
+
 ### src/exa_websets.py and src/check_webset.py
 
-These scripts generate output in JSON format with the following structure:
+These scripts generate output in two formats:
+
+1. JSON format with the following structure:
 
 ```json
 {
@@ -189,6 +200,8 @@ These scripts generate output in JSON format with the following structure:
   ]
 }
 ```
+
+2. Excel format (.xlsx) - Tabular data with the same information, suitable for analysis and processing in spreadsheet applications. Missing fields are kept blank rather than filled with null values.
 
 ## Configuration
 
@@ -224,6 +237,21 @@ The scripts include error handling for:
 
 - The Exa Websets API is asynchronous, so it may take some time for a Webset to process.
 - The enrichments may not always be able to extract all requested information for every result.
+
+## Running Tests
+
+The project includes tests to verify the functionality of the Excel export feature and integration with the main scripts. To run the tests:
+
+```bash
+pytest tests/
+```
+
+Or run specific test files:
+
+```bash
+pytest tests/test_excel_export.py
+pytest tests/test_integration.py
+```
 
 ## License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+exa-py>=1.0.0
+python-dotenv>=1.0.0
+requests>=2.31.0
+beautifulsoup4>=4.12.0
+pandas>=2.0.0
+openpyxl>=3.1.0
+pytest>=7.3.1
+pytest-mock>=3.10.0

--- a/src/check_webset.py
+++ b/src/check_webset.py
@@ -16,6 +16,7 @@ import argparse
 from typing import Dict, List, Any, Optional
 from dotenv import load_dotenv
 from exa_py import Exa
+from src.utils.excel_export import json_to_excel
 
 def load_config(config_file: str) -> Dict[str, Any]:
     """
@@ -298,9 +299,19 @@ def format_and_save_results(items: List[Dict[str, Any]], config: Dict[str, Any],
                     except:
                         return "Non-serializable object"
 
+            # Save to JSON file
+            json_data = {"results": formatted_results}
             with open(output_file, 'w', encoding='utf-8') as f:
-                json.dump({"results": formatted_results}, f, indent=2, cls=CustomEncoder)
+                json.dump(json_data, f, indent=2, cls=CustomEncoder)
             print(f"\nResults saved to {output_file}")
+
+            # Save to Excel file
+            try:
+                excel_file = json_to_excel(json_data, output_file)
+                if excel_file:
+                    print(f"Results also saved to Excel file: {excel_file}")
+            except Exception as e:
+                print(f"Error saving results to Excel file: {e}")
         except Exception as e:
             print(f"Error saving results to file: {e}")
 

--- a/src/exa_search.py
+++ b/src/exa_search.py
@@ -25,6 +25,7 @@ import argparse
 from typing import Dict, List, Any, Optional
 from dotenv import load_dotenv
 from exa_py import Exa
+from src.utils.excel_export import search_results_to_excel
 
 # Maximum number of items to display
 MAX_ITEMS = 3
@@ -203,9 +204,20 @@ def format_and_display_results(results: List[Dict[str, Any]], query: str, output
     # Save to file if requested
     if output_file:
         try:
+            # Save to text file
             with open(output_file, 'w', encoding='utf-8') as f:
                 f.write(output_text)
             print(f"\nResults saved to {output_file}")
+
+            # Save to Excel file
+            try:
+                # Extract metadata for Excel export
+                excel_data = [extract_metadata(result) for result in results]
+                excel_file = search_results_to_excel(excel_data, query, output_file)
+                if excel_file:
+                    print(f"Results also saved to Excel file: {excel_file}")
+            except Exception as e:
+                print(f"Error saving results to Excel file: {e}")
         except Exception as e:
             print(f"Error saving results to file: {e}")
 

--- a/src/exa_websets.py
+++ b/src/exa_websets.py
@@ -23,6 +23,7 @@ from typing import Dict, List, Any, Optional
 from dotenv import load_dotenv
 from exa_py import Exa
 from exa_py.websets.types import CreateWebsetParameters, CreateEnrichmentParameters
+from src.utils.excel_export import json_to_excel
 
 # Default timeout for waiting for Webset processing (in seconds)
 TIMEOUT = 300  # 5 minutes
@@ -348,9 +349,19 @@ def format_and_save_results(items: List[Dict[str, Any]], config: Dict[str, Any],
                         json_result[key] = value
                 json_results.append(json_result)
 
+            # Save to JSON file
+            json_data = {"results": json_results}
             with open(output_file, 'w', encoding='utf-8') as f:
-                json.dump({"results": json_results}, f, indent=2)
+                json.dump(json_data, f, indent=2)
             print(f"\nResults saved to {output_file}")
+
+            # Save to Excel file
+            try:
+                excel_file = json_to_excel(json_data, output_file)
+                if excel_file:
+                    print(f"Results also saved to Excel file: {excel_file}")
+            except Exception as e:
+                print(f"Error saving results to Excel file: {e}")
         except Exception as e:
             print(f"Error saving results to file: {e}")
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for the Exa API scripts."""

--- a/src/utils/excel_export.py
+++ b/src/utils/excel_export.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Excel Export Utility
+
+This module provides functions to export data to Excel/Google Sheets format.
+"""
+
+import os
+import pandas as pd
+from typing import Dict, List, Any, Optional
+
+
+def ensure_results_dir(base_dir: str = "../results") -> str:
+    """
+    Ensure the results directory exists.
+
+    Args:
+        base_dir: Base directory for results
+
+    Returns:
+        str: Path to the results directory
+    """
+    if not os.path.exists(base_dir):
+        os.makedirs(base_dir)
+    return base_dir
+
+
+def json_to_excel(
+    data: Dict[str, List[Dict[str, Any]]],
+    output_file: str,
+    sheet_name: str = "Results"
+) -> str:
+    """
+    Convert JSON data to Excel format and save to file.
+
+    Args:
+        data: JSON data to convert (expected format: {"results": [...]})
+        output_file: Output file path for JSON (will be modified for Excel)
+        sheet_name: Name of the sheet in the Excel file
+
+    Returns:
+        str: Path to the saved Excel file
+    """
+    # Extract results from data
+    results = data.get("results", [])
+    if not results:
+        return ""
+
+    # Create a list to hold flattened data
+    flattened_data = []
+
+    # Process each result
+    for result in results:
+        # Start with basic fields
+        flat_result = {
+            "id": result.get("id", ""),
+            "source": result.get("source", ""),
+            "webset_id": result.get("webset_id", ""),
+            "url": result.get("url", "")
+        }
+
+        # Add enrichments if available
+        enrichments = result.get("enrichments", {})
+        for field, value in enrichments.items():
+            # Handle list values by taking the first item
+            if isinstance(value, list) and value:
+                flat_result[field] = value[0]
+            else:
+                flat_result[field] = value
+
+        flattened_data.append(flat_result)
+
+    # Convert to DataFrame
+    df = pd.DataFrame(flattened_data)
+
+    # Convert numeric-looking strings to strings to prevent auto-conversion
+    for col in df.columns:
+        if col in ['Phone', 'Email']:
+            # Convert to string and remove decimal point and zeros for numeric values
+            df[col] = df[col].apply(lambda x: str(int(float(x))) if pd.notnull(x) and str(x).replace('.', '').isdigit() else x)
+
+    # Generate Excel file path from JSON path
+    excel_file = output_file.replace(".json", ".xlsx")
+
+    # Save to Excel
+    df.to_excel(excel_file, sheet_name=sheet_name, index=False)
+
+    return excel_file
+
+
+def search_results_to_excel(
+    results: List[Dict[str, Any]],
+    query: str,
+    output_file: Optional[str] = None
+) -> Optional[str]:
+    """
+    Convert search results to Excel format and save to file.
+
+    Args:
+        results: List of search results
+        query: The search query used
+        output_file: Optional file path to save results to
+
+    Returns:
+        Optional[str]: Path to the saved Excel file or None if no output file
+    """
+    if not results or not output_file:
+        return None
+
+    # Create a list to hold flattened data
+    flattened_data = []
+
+    # Process each result
+    for result in results:
+        # Extract metadata
+        metadata = {
+            "title": result.get("title", ""),
+            "url": result.get("url", ""),
+            "published_date": result.get("published_date", ""),
+            "author": result.get("author", ""),
+            "source": result.get("source", ""),
+            "score": result.get("score", ""),
+            "text": result.get("text", "")[:300]  # Truncate text to a reasonable length
+        }
+
+        flattened_data.append(metadata)
+
+    # Convert to DataFrame
+    df = pd.DataFrame(flattened_data)
+
+    # Generate Excel file path from text path
+    excel_file = output_file.replace(".txt", ".xlsx")
+
+    # Save to Excel - replace invalid characters in sheet name
+    safe_query = query[:30].replace(':', '-').replace('/', '-').replace('\\', '-').replace('?', '-').replace('*', '-').replace('[', '(').replace(']', ')')
+    df.to_excel(excel_file, sheet_name=f"Search {safe_query}", index=False)
+
+    return excel_file

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for Exa API scripts."""

--- a/tests/test_excel_export.py
+++ b/tests/test_excel_export.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Tests for Excel Export Utility
+
+This module tests the functionality of the Excel export utility.
+"""
+
+import os
+import json
+import pandas as pd
+import pytest
+from src.utils.excel_export import json_to_excel, search_results_to_excel
+
+
+@pytest.fixture
+def sample_json_data():
+    """Sample JSON data for testing."""
+    return {
+        "results": [
+            {
+                "id": "witem_01jvcj1fhwy2c68zxyy2c68zxy",
+                "source": "search",
+                "webset_id": "webset_cmaqsk393000tlq0icayjcwg0",
+                "url": "https://www.linkedin.com/in/jan-mccarthy-4872517",
+                "enrichments": {
+                    "Company Website": "https://www.janmccarthy.com",
+                    "Location": "Los Angeles, California",
+                    "Email": "tkgcareofbusiness@gmail.com",
+                    "Phone": "3039562712"
+                }
+            },
+            {
+                "id": "witem_01jvcj1ggy0mydqpj00mydqpj0",
+                "source": "search",
+                "webset_id": "webset_cmaqsk393000tlq0icayjcwg0",
+                "url": "https://www.linkedin.com/in/sheila-thorne-3867a576",
+                "enrichments": {
+                    "Company Website": "https://www.woce.us",
+                    "Location": "Palos Verdes Peninsula, California"
+                    # Note: Missing Phone field
+                }
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def sample_search_results():
+    """Sample search results for testing."""
+    return [
+        {
+            "title": "OpenAI",
+            "url": "https://openai.com/",
+            "published_date": "2025-05-05T00:00:00.000Z",
+            "author": "OpenAI Team",
+            "source": "openai.com",
+            "score": 0.95,
+            "text": "OpenAI is an AI research lab consisting of the for-profit company OpenAI LP and its parent company, the non-profit OpenAI Inc."
+        },
+        {
+            "title": "Anthropic",
+            "url": "https://www.anthropic.com/",
+            "published_date": "2025-03-27T00:00:00.000Z",
+            # Note: Missing author field
+            "source": "anthropic.com",
+            "score": 0.85,
+            "text": "Anthropic is an AI safety company that's working to build reliable, interpretable, and steerable AI systems."
+        }
+    ]
+
+
+def test_json_to_excel(sample_json_data, tmp_path):
+    """Test converting JSON data to Excel format."""
+    # Create a temporary JSON file
+    json_file = tmp_path / "test_data.json"
+    with open(json_file, 'w', encoding='utf-8') as f:
+        json.dump(sample_json_data, f)
+
+    # Convert to Excel
+    excel_file = json_to_excel(sample_json_data, str(json_file))
+
+    # Check that the Excel file was created
+    assert os.path.exists(excel_file)
+
+    # Read the Excel file and check its contents
+    df = pd.read_excel(excel_file)
+
+    # Check that we have the right number of rows
+    assert len(df) == 2
+
+    # Check that the columns include both basic fields and enrichments
+    expected_columns = ['id', 'source', 'webset_id', 'url', 'Company Website', 'Location', 'Email', 'Phone']
+    for col in expected_columns:
+        assert col in df.columns
+
+    # Check that the data was correctly transferred
+    assert df.iloc[0]['id'] == "witem_01jvcj1fhwy2c68zxyy2c68zxy"
+    assert df.iloc[0]['Email'] == "tkgcareofbusiness@gmail.com"
+    # Phone should contain the correct digits, regardless of format
+    phone = str(df.iloc[0]['Phone']).strip()
+    assert phone.replace('.0', '').replace('.', '') == "3039562712"
+
+    # Check that missing fields are empty (not filled with NaN)
+    # The second record is missing the Phone field
+    assert pd.isna(df.iloc[1]['Phone']) or df.iloc[1]['Phone'] == ""
+
+
+def test_search_results_to_excel(sample_search_results, tmp_path):
+    """Test converting search results to Excel format."""
+    # Create a temporary text file
+    text_file = tmp_path / "test_search.txt"
+    with open(text_file, 'w', encoding='utf-8') as f:
+        f.write("Test search results")
+
+    # Convert to Excel
+    query = "AI research labs"
+    excel_file = search_results_to_excel(sample_search_results, query, str(text_file))
+
+    # Check that the Excel file was created
+    assert os.path.exists(excel_file)
+
+    # Read the Excel file and check its contents
+    df = pd.read_excel(excel_file)
+
+    # Check that we have the right number of rows
+    assert len(df) == 2
+
+    # Check that the columns include all expected fields
+    expected_columns = ['title', 'url', 'published_date', 'author', 'source', 'score', 'text']
+    for col in expected_columns:
+        assert col in df.columns
+
+    # Check that the data was correctly transferred
+    assert df.iloc[0]['title'] == "OpenAI"
+    assert df.iloc[0]['author'] == "OpenAI Team"
+
+    # Check that missing fields are empty (not filled with NaN)
+    # The second record is missing the author field
+    assert pd.isna(df.iloc[1]['author']) or df.iloc[1]['author'] == ""
+
+
+def test_json_to_excel_empty_data():
+    """Test handling of empty data."""
+    # Test with empty results
+    empty_data = {"results": []}
+    result = json_to_excel(empty_data, "test_empty.json")
+    assert result == ""
+
+
+def test_search_results_to_excel_empty_data():
+    """Test handling of empty search results."""
+    # Test with empty results
+    empty_results = []
+    result = search_results_to_excel(empty_results, "test query", "test_empty.txt")
+    assert result is None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Integration Tests for Exa API Scripts
+
+This module tests the integration of Excel export functionality with the main scripts.
+"""
+
+import os
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+import pandas as pd
+import sys
+sys.path.insert(0, '.')  # Add the current directory to the path
+
+# Import the functions to test
+from src.exa_websets import format_and_save_results as websets_format_and_save
+from src.check_webset import format_and_save_results as check_webset_format_and_save
+from src.exa_search import format_and_display_results
+
+
+@pytest.fixture
+def sample_webset_items():
+    """Sample Webset items for testing."""
+    # Create a mock item with the necessary attributes
+    item1 = MagicMock()
+    item1.id = "witem_01jvcj1fhwy2c68zxyy2c68zxy"
+    item1.source = "search"
+    item1.webset_id = "webset_cmaqsk393000tlq0icayjcwg0"
+
+    # Mock properties
+    properties = MagicMock()
+    properties.url = "https://www.linkedin.com/in/jan-mccarthy-4872517"
+    item1.properties = properties
+
+    # Mock enrichments
+    enrichment1 = MagicMock()
+    enrichment1.enrichment_id = "wenrich_cmaqsapcr00csl00iv9o50m44"
+    enrichment1.format = "email"
+    enrichment1.result = "tkgcareofbusiness@gmail.com"
+    enrichment1.__str__ = lambda self: "tkgcareofbusiness@gmail.com"
+
+    enrichment2 = MagicMock()
+    enrichment2.enrichment_id = "wenrich_cmaqsapcr00ctl00iq4gpyqo6"
+    enrichment2.format = "phone"
+    enrichment2.result = "3039562712"
+    enrichment2.__str__ = lambda self: "3039562712"
+
+    enrichment3 = MagicMock()
+    enrichment3.enrichment_id = "wenrich_cmaqsapcr00cul00i3l2dfhq7"
+    enrichment3.format = "text"
+    enrichment3.result = "Los Angeles, California"
+    enrichment3.__str__ = lambda self: "Los Angeles, California"
+
+    item1.enrichments = [enrichment1, enrichment2, enrichment3]
+
+    # Create a second item with missing fields
+    item2 = MagicMock()
+    item2.id = "witem_01jvcj1ggy0mydqpj00mydqpj0"
+    item2.source = "search"
+    item2.webset_id = "webset_cmaqsk393000tlq0icayjcwg0"
+
+    # Mock properties
+    properties2 = MagicMock()
+    properties2.url = "https://www.linkedin.com/in/sheila-thorne-3867a576"
+    item2.properties = properties2
+
+    # Mock enrichments - missing phone
+    enrichment4 = MagicMock()
+    enrichment4.enrichment_id = "wenrich_cmaqsapcr00cwl00ij7q5v78o"
+    enrichment4.format = "url"
+    enrichment4.result = "https://www.woce.us"
+    enrichment4.__str__ = lambda self: "https://www.woce.us"
+
+    enrichment5 = MagicMock()
+    enrichment5.enrichment_id = "wenrich_cmaqsapcr00cul00i3l2dfhq7"
+    enrichment5.format = "text"
+    enrichment5.result = "Palos Verdes Peninsula, California"
+    enrichment5.__str__ = lambda self: "Palos Verdes Peninsula, California"
+
+    item2.enrichments = [enrichment4, enrichment5]
+
+    return [item1, item2]
+
+
+@pytest.fixture
+def sample_search_results():
+    """Sample search results for testing."""
+    # Create mock search results
+    result1 = MagicMock()
+    result1.title = "OpenAI"
+    result1.url = "https://openai.com/"
+    result1.published_date = "2025-05-05T00:00:00.000Z"
+    result1.author = "OpenAI Team"
+    result1.source = "openai.com"
+    result1.score = 0.95
+    result1.text = "OpenAI is an AI research lab consisting of the for-profit company OpenAI LP and its parent company, the non-profit OpenAI Inc."
+
+    result2 = MagicMock()
+    result2.title = "Anthropic"
+    result2.url = "https://www.anthropic.com/"
+    result2.published_date = "2025-03-27T00:00:00.000Z"
+    # Missing author field
+    result2.source = "anthropic.com"
+    result2.score = 0.85
+    result2.text = "Anthropic is an AI safety company that's working to build reliable, interpretable, and steerable AI systems."
+
+    return [result1, result2]
+
+
+@pytest.fixture
+def config():
+    """Sample configuration for testing."""
+    return {
+        "enrichments": [
+            "Name",
+            "Email",
+            "Phone",
+            "Location",
+            "Company Name",
+            "Company Website"
+        ]
+    }
+
+
+def test_websets_format_and_save_results(sample_webset_items, config, tmp_path):
+    """Test that websets format_and_save_results creates JSON files."""
+    # Create output file path
+    output_file = str(tmp_path / "test_websets_results.json")
+
+    # Call the function with mocked json_to_excel to avoid actual Excel file creation
+    with patch('src.utils.excel_export.json_to_excel', return_value="mock.xlsx"):
+        with patch('builtins.print'):  # Suppress print statements
+            websets_format_and_save(sample_webset_items, config, output_file)
+
+    # Check that the JSON file was created
+    assert os.path.exists(output_file)
+
+
+def test_check_webset_format_and_save_results(sample_webset_items, config, tmp_path):
+    """Test that check_webset format_and_save_results creates JSON files."""
+    # Create output file path
+    output_file = str(tmp_path / "test_check_webset_results.json")
+
+    # Call the function with mocked json_to_excel to avoid actual Excel file creation
+    with patch('src.utils.excel_export.json_to_excel', return_value="mock.xlsx"):
+        with patch('builtins.print'):  # Suppress print statements
+            check_webset_format_and_save(sample_webset_items, config, output_file)
+
+    # Check that the JSON file was created
+    assert os.path.exists(output_file)
+
+
+def test_search_format_and_display_results(sample_search_results, tmp_path):
+    """Test that search format_and_display_results creates text files."""
+    # Create output file path
+    output_file = str(tmp_path / "test_search_results.txt")
+
+    # Call the function with mocked search_results_to_excel to avoid actual Excel file creation
+    with patch('src.utils.excel_export.search_results_to_excel', return_value="mock.xlsx"):
+        with patch('builtins.print'):  # Suppress print statements
+            format_and_display_results(sample_search_results, "Test query", output_file)
+
+    # Check that the text file was created
+    assert os.path.exists(output_file)
+
+    # Check text content
+    with open(output_file, 'r', encoding='utf-8') as f:
+        text_content = f.read()
+    assert "OpenAI" in text_content
+    assert "Anthropic" in text_content


### PR DESCRIPTION
## Description
This PR adds functionality to store response results in both JSON and Excel/Google Sheets formats in the results folder. Key features:

- Added Excel/Google Sheets export for all scripts (exa_websets.py, check_webset.py, exa_search.py)
- Implemented proper handling of missing fields (keeping them blank rather than filling with null values)
- Created comprehensive tests for the new functionality
- Updated documentation

## Changes
- Created a utility module `src/utils/excel_export.py` with functions to convert JSON data to Excel format
- Modified existing scripts to include Excel export functionality
- Added unit and integration tests
- Updated README with new functionality details
- Added requirements.txt file with necessary dependencies

## Testing
All tests pass successfully. The implementation has been tested with various data formats and edge cases.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author